### PR TITLE
Add btc and overview specifications

### DIFF
--- a/docs/btc.md
+++ b/docs/btc.md
@@ -1,0 +1,102 @@
+# CCC BTC Lock Specification
+This specification describes a CCC lock script that can interoperate with the
+BTC blockchain. Some common designs, definitions, and conventions can be found
+in the [overview](./overview.md).
+
+## Lock Script
+A CCC BTC lock script has following structure:
+```
+Code hash: CCC BTC lock script code hash
+Hash type: CCC BTC lock script hash type
+Args:  <secp256k1 pubkey hash, 20 bytes>
+```
+This secp256k1 pubkey hash is calculate via SHA-256 and RIPEMD-160 over
+compressed secp256k1 pubkey(33 bytes).
+
+## Supported BTC Addresses
+The following address types are supported:
+- P2PKH
+- P2WPKH
+
+The secp256k1 pubkey hash can be decoded from address via base58 or bech32m(bech32).
+
+
+## Witness
+The corresponding witness must be a proper `WitnessArgs` data structure in
+molecule format. In the lock field of the WitnessArgs, a 65 bytes secp256k1
+signature must be present.
+
+The first byte of the signature is the `recId` described in [BIP
+0137](https://github.com/bitcoin/bips/blob/master/bip-0137.mediawiki#procedure-for-signingverifying-a-signature).
+This `recId` ranges from 0 to 3. The `r` and `s` values follow it.
+
+## Unlocking Process
+The following bytes are hashed via SHA-256 over SHA-256 (double SHA-256):
+
+1. A byte representing the length of the following string (24).
+2. A string with 24 bytes: "Bitcoin Signed Message:\n".
+3. A byte representing the length of the following string.
+4. A string with bytes:
+
+"Signing a CKB transaction: 0x{sigh_hash}\n\nIMPORTANT: Please verify the integrity and authenticity of connected BTC wallet before signing this message\n"
+
+The `{sighasl_all}` is replaced by `sighash_all` in hexadecimal string, with length 64. The
+string in the last part can be displayed in wallet UIs.
+
+After hashing, this hash value is the message used in secp256k1 verification.
+The signature with `recId` is used to recover pubkey(compressed), according to
+the message above. If the SHA-256 and RIPEMD-160 over recovered compressed
+pubkey is identical to script args, then the script is validated successfully.
+
+## Examples
+
+```yaml
+CellDeps:
+    <vec> CCC BTC lock script cell
+Inputs:
+    <vec> Cell
+        Data: <...>
+        Type: <...>
+        Lock:
+            code_hash: <CCC BTC lock script code hash>
+            args: <secp256k1 pubkey hash, 20 bytes>
+Outputs:
+    <vec> Any cell
+Witnesses:
+    <vec> WitnessArgs
+      Lock: <recId, 1 byte> <r, 32 bytes> <s, 32 bytes>
+```
+
+
+
+## Notes
+
+An implementation of the lock script spec above has been deployed to CKB mainnet and testnet:
+
+- mainnet
+
+| parameter   | value                                                                |
+| ----------- | -------------------------------------------------------------------- |
+| `code_hash` | TODO   |
+| `hash_type` | `type`                                                               |
+| `tx_hash`   | TODO   |
+| `index`     | `0x0`                                                                |
+| `dep_type`  | `code`                                                               |
+
+- testnet
+
+| parameter   | value                                                                |
+| ----------- | -------------------------------------------------------------------- |
+| `code_hash` | TODO   |
+| `hash_type` | `type`                                                               |
+| `tx_hash`   | TODO   |
+| `index`     | `0x0`                                                                |
+| `dep_type`  | `code`                                                               |
+
+Reproducible build is supported to verify the deployed script. To build the
+deployed script above, one can use the following steps:
+
+```bash
+TODO
+```
+

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,45 @@
+# CCC Locks Overview
+## Introduction
+[CCC (Common Chains Connector)](https://github.com/ckb-ecofund/ccc) helps
+developers interoperate wallets from different chain ecosystems with CKB, fully
+enabling CKB's cryptographic freedom power. In this overview specification, we
+describe some common designs, definitions, and conventions. The lock
+specifications for dedicated chains can be found in other documents. The
+definitions and conventions in this section apply to all CCC lock
+specifications, including BTC, ETH, and more.
+
+
+## `ckbhash`
+CKB uses blake2b as the default hash algorithm. We use `ckbhash` to denote the
+blake2b hash function with following configuration:
+
+- output digest size: 32
+- personalization: ckb-default-hash
+
+The `blake160` function is defined to return the leading 20 bytes of the `ckbhash` result.
+
+
+## sighash_all
+
+A 32-byte `sighash_all` message can be calculated via `ckbhash` with following data:
+
+* Transaction hash
+* Witness length and content in same script group covered by inputs, excluding lock field
+* Other witness length and content that not covered by inputs
+
+A reference implementation in C can be found [here](https://github.com/nervosnetwork/ckb-system-scripts/blob/a7b7c75662ed950c9bd024e15f83ce702a54996e/c/secp256k1_blake160_sighash_all.c#L219).
+
+## WitnessArgs
+When unlocking a CCC lock script, the corresponding witness must be a proper
+`WitnessArgs` data structure in molecule format. In the lock field of the
+WitnessArgs, a signature must be present. Signatures can be different for
+different chains.
+
+## Hexadecimal String
+Only lowercase letters can be used in hexadecimal strings. For example, "00" and
+"ffee" are valid hexadecimal strings, while "FFEE" and "hello world" are not
+valid. 
+
+## Links
+- [BTC](./btc.md)
+- ETH


### PR DESCRIPTION
In the overview specification(overview.md), we describe some common designs, definitions, and conventions. The lock specifications for dedicated chains can be found in other documents(e.g. btc.md). 

